### PR TITLE
Optimize `open_repo()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ RoxygenNote: 6.0.1.9000
 Imports: 
     rprojroot,
     glue,
-    cli,
+    cli (>= 1.9.9.9000),
     purrr,
     rlang,
     tibble,

--- a/R/open.R
+++ b/R/open.R
@@ -4,7 +4,8 @@
 #' regex (i.e. substring matches) are allowed.
 #' @param n For partial matches, the ID of repos to open in parallel. Can be a
 #'   single integer, a sequence (`3:7`) or a vector (`c(2, 5)`). For `n = 1`,
-#'   the exact match is opened.
+#'   the exact match is opened (if there is one) otherwise the best regex fit is
+#'   opened.
 #' @param project A character vector of length one with a project name.
 #'   Can be left `NULL` if the repo name is unique across all projects.
 #' @param dir Any directory under the team root.
@@ -18,28 +19,28 @@ open_repo <- function(repo = "meta",
                       project = NULL,
                       dir = ".",
                       newSession = TRUE) {
-  
-  
+
+
   repos <- git_dirs(dir)
   is_repo_match <- grepl(repo, basename(repos), fixed = TRUE)
   matching_repo <- repos[is_repo_match]
-  
+
   if (all(!is_repo_match)) stop("Make sure the repo exists.", call. = FALSE)
   if (!is.null(project)) {
     is_project_match <- basename(dirname(repos)) == project
     matching_repo <- repos[is_repo_match & is_project_match]
   }
-  
+
   if (!is.null(n) && sum(is_repo_match) > n) {
     cli::cli_text("Argument {.code repo = {repo}} results in multiple partial matches:")
     cli::cat_bullet(matching_repo)
-    
+
     # check if we have exact match
     exact_match <- which(basename(repos) == repo)
     if (n == 1 && length(exact_match == 1)) {
       cli::cli_text("We've found one exact match. Opening project {.code {repo}}.")
       rstudioapi::openProject(matching_repo[which(basename(matching_repo) == repo)],
-                              newSession = newSession
+        newSession = newSession
       )
       return(invisible(TRUE))
     } else {

--- a/R/open.R
+++ b/R/open.R
@@ -1,22 +1,25 @@
 #' Open an RStudio Project from a repository
-#' 
+#'
 #' @param repo A character vector of length one with a repository name. Fixed
-#'   regex (i.e. substring matches) are allowed.
-#' @param n The number upper bound of repos to open. If `NULL`, all will be 
-#' opened.
-#' @param project A character vector of length one with a project name. 
-#'   Can be left `NULL` if the repo name is unique accros all projects.
+#' regex (i.e. substring matches) are allowed.
+#' @param n For partial matches, the ID of repos to open in parallel. Can be a
+#'   single integer, a sequence (`3:7`) or a vector (`c(2, 5)`). For `n = 1`,
+#'   the exact match is opened.
+#' @param project A character vector of length one with a project name.
+#'   Can be left `NULL` if the repo name is unique across all projects.
 #' @param dir Any directory under the team root.
-#' @param newSession whether or not to open the RStudio Project in a new 
+#' @param newSession whether or not to open the RStudio Project in a new
 #'   session.
-#' @importFrom rlang abort 
+#' @importFrom rlang abort
 #' @importFrom purrr walk
 #' @export
-open_repo <- function(repo = "meta", 
+open_repo <- function(repo = "meta",
                       n = 1,
-                      project = NULL, 
-                      dir = ".", 
+                      project = NULL,
+                      dir = ".",
                       newSession = TRUE) {
+  
+  
   repos <- git_dirs(dir)
   is_repo_match <- grepl(repo, basename(repos), fixed = TRUE)
   matching_repo <- repos[is_repo_match]
@@ -28,13 +31,25 @@ open_repo <- function(repo = "meta",
   }
   
   if (!is.null(n) && sum(is_repo_match) > n) {
-    cli::cat_line("argument repo matches multiple repos:")
+    cli::cli_text("Argument {.code repo = {repo}} results in multiple partial matches:")
     cli::cat_bullet(matching_repo)
-    abort(paste(
-      "Set argument n to NULL to open all repos, or to an integer,",
-      "to open the first n of them."
-    ))
+    
+    # check if we have exact match
+    exact_match <- which(basename(repos) == repo)
+    if (n == 1 && length(exact_match == 1)) {
+      cli::cli_text("We've found one exact match. Opening project {.code {repo}}.")
+      rstudioapi::openProject(matching_repo[which(basename(matching_repo) == repo)],
+                              newSession = newSession
+      )
+      return(invisible(TRUE))
+    } else {
+      walk(matching_repo[n], ~ {
+        rstudioapi::openProject(.x, newSession = newSession)
+        # need to wait a bit otherwise the first repo gets opened multiple times
+        Sys.sleep(1)
+      })
+    }
+  } else {
+    walk(matching_repo, rstudioapi::openProject, newSession = newSession)
   }
-  
-  walk(matching_repo, rstudioapi::openProject, newSession = newSession)
 }

--- a/R/open.R
+++ b/R/open.R
@@ -43,6 +43,7 @@ open_repo <- function(repo = "meta",
       )
       return(invisible(TRUE))
     } else {
+      cli::cli_text("\nOpening projects {.code {basename(matching_repo[n])}}.")
       walk(matching_repo[n], ~ {
         rstudioapi::openProject(.x, newSession = newSession)
         # need to wait a bit otherwise the first repo gets opened multiple times

--- a/man/communicate_remote.Rd
+++ b/man/communicate_remote.Rd
@@ -4,8 +4,12 @@
 \alias{communicate_remote}
 \title{Communicate with a remote}
 \usage{
-communicate_remote(dir, fun = pull, credentials = NULL,
-  communicate_result = TRUE)
+communicate_remote(
+  dir,
+  fun = pull,
+  credentials = NULL,
+  communicate_result = TRUE
+)
 }
 \arguments{
 \item{dir}{A directory.}

--- a/man/find_repo_root.Rd
+++ b/man/find_repo_root.Rd
@@ -7,10 +7,11 @@
 find_repo_root(...)
 }
 \arguments{
-\item{...}{Arguments passed on to \code{find_root_from_dir}
-\describe{
-  \item{}{}
-}}
+\item{...}{
+  Arguments passed on to \code{\link[=find_root_from_dir]{find_root_from_dir}}
+  \describe{
+    \item{\code{}}{}
+  }}
 }
 \description{
 Simly go up the tree until a \code{.git} folder is found.

--- a/man/find_root_from_dir.Rd
+++ b/man/find_root_from_dir.Rd
@@ -7,15 +7,16 @@
 find_root_from_dir(...)
 }
 \arguments{
-\item{...}{Arguments passed on to \code{find_root_from_object}
-\describe{
-  \item{root_object}{A file or directory in a directory that qualifies the
+\item{...}{
+  Arguments passed on to \code{\link[=find_root_from_object]{find_root_from_object}}
+  \describe{
+    \item{\code{root_object}}{A file or directory in a directory that qualifies the
 latter as a root.}
-  \item{dir}{The directory to start the search from.}
-  \item{object_finder}{A function that is applied to the \code{root_object}. If
+    \item{\code{dir}}{The directory to start the search from.}
+    \item{\code{object_finder}}{A function that is applied to the \code{root_object}. If
 the root object is a file, use \code{\link[rprojroot:has_file]{rprojroot::has_file()}}, if it is a
 directory, use \code{\link[rprojroot:has_dir]{rprojroot::has_dir()}}.}
-}}
+  }}
 }
 \description{
 Find a root given a directory that must exist there

--- a/man/find_root_from_file.Rd
+++ b/man/find_root_from_file.Rd
@@ -7,15 +7,16 @@
 find_root_from_file(...)
 }
 \arguments{
-\item{...}{Arguments passed on to \code{find_root_from_object}
-\describe{
-  \item{root_object}{A file or directory in a directory that qualifies the
+\item{...}{
+  Arguments passed on to \code{\link[=find_root_from_object]{find_root_from_object}}
+  \describe{
+    \item{\code{root_object}}{A file or directory in a directory that qualifies the
 latter as a root.}
-  \item{dir}{The directory to start the search from.}
-  \item{object_finder}{A function that is applied to the \code{root_object}. If
+    \item{\code{dir}}{The directory to start the search from.}
+    \item{\code{object_finder}}{A function that is applied to the \code{root_object}. If
 the root object is a file, use \code{\link[rprojroot:has_file]{rprojroot::has_file()}}, if it is a
 directory, use \code{\link[rprojroot:has_dir]{rprojroot::has_dir()}}.}
-}}
+  }}
 }
 \description{
 Find a root given a directory that must exist there

--- a/man/find_team_root.Rd
+++ b/man/find_team_root.Rd
@@ -7,10 +7,11 @@
 find_team_root(...)
 }
 \arguments{
-\item{...}{Arguments passed on to \code{find_root_from_file}
-\describe{
-  \item{}{}
-}}
+\item{...}{
+  Arguments passed on to \code{\link[=find_root_from_file]{find_root_from_file}}
+  \describe{
+    \item{\code{}}{}
+  }}
 }
 \description{
 Find a team root

--- a/man/open_repo.Rd
+++ b/man/open_repo.Rd
@@ -12,7 +12,8 @@ regex (i.e. substring matches) are allowed.}
 
 \item{n}{For partial matches, the ID of repos to open in parallel. Can be a
 single integer, a sequence (\code{3:7}) or a vector (\code{c(2, 5)}). For \code{n = 1},
-the exact match is opened.}
+the exact match is opened (if there is one) otherwise the best regex fit is
+opened.}
 
 \item{project}{A character vector of length one with a project name.
 Can be left \code{NULL} if the repo name is unique across all projects.}

--- a/man/open_repo.Rd
+++ b/man/open_repo.Rd
@@ -4,18 +4,18 @@
 \alias{open_repo}
 \title{Open an RStudio Project from a repository}
 \usage{
-open_repo(repo = "meta", n = 1, project = NULL, dir = ".",
-  newSession = TRUE)
+open_repo(repo = "meta", n = 1, project = NULL, dir = ".", newSession = TRUE)
 }
 \arguments{
 \item{repo}{A character vector of length one with a repository name. Fixed
 regex (i.e. substring matches) are allowed.}
 
-\item{n}{The number upper bound of repos to open. If \code{NULL}, all will be
-opened.}
+\item{n}{For partial matches, the ID of repos to open in parallel. Can be a
+single integer, a sequence (\code{3:7}) or a vector (\code{c(2, 5)}). For \code{n = 1},
+the exact match is opened.}
 
 \item{project}{A character vector of length one with a project name.
-Can be left \code{NULL} if the repo name is unique accros all projects.}
+Can be left \code{NULL} if the repo name is unique across all projects.}
 
 \item{dir}{Any directory under the team root.}
 

--- a/man/structure.Rd
+++ b/man/structure.Rd
@@ -19,6 +19,6 @@ Further:
 \item Put a .description file in every repo that you want to describe and add
 a markdown-like description to it.
 \item Paste the contents of description into the README using
-\code{r paste(readLines(".description"), collapse = '\n')}.
+\verb{r paste(readLines(".description"), collapse = '\\n')}.
 }
 }

--- a/teamtools.Rproj
+++ b/teamtools.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
- If `n = 1`, the exact match will be opened.

- `n` can be supplied as a vector and if multiples matches are found, those will be opened.

- .Rproj: Enable CTRL+Shift+D hotkey for documenting

```r
open_repo("mlr3", n = c(7, 9))
Argument `repo = mlr3` results in multiple partial matches:
● /home/pjs/git/mlr-org/mlr3-learndrake
● /home/pjs/git/mlr-org/mlr3.wiki
● /home/pjs/git/mlr-org/mlr3
● /home/pjs/git/mlr-org/mlr3book
● /home/pjs/git/mlr-org/mlr3cluster
● /home/pjs/git/mlr-org/mlr3db
● /home/pjs/git/mlr-org/mlr3fda
● /home/pjs/git/mlr-org/mlr3filters
● /home/pjs/git/mlr-org/mlr3forecasting
● /home/pjs/git/mlr-org/mlr3fselect
● /home/pjs/git/mlr-org/mlr3hyperband
● /home/pjs/git/mlr-org/mlr3keras
● /home/pjs/git/mlr-org/mlr3learners
● /home/pjs/git/mlr-org/mlr3measures
● /home/pjs/git/mlr-org/mlr3misc
● /home/pjs/git/mlr-org/mlr3ordinal
● /home/pjs/git/mlr-org/mlr3pipelines
● /home/pjs/git/mlr-org/mlr3pkgdowntemplate
● /home/pjs/git/mlr-org/mlr3proba
● /home/pjs/git/mlr-org/mlr3spatiotempcv
● /home/pjs/git/mlr-org/mlr3survival
● /home/pjs/git/mlr-org/mlr3tuning
● /home/pjs/git/mlr-org/mlr3verse
● /home/pjs/git/mlr-org/mlr3viz
Opening projects `mlr3fda` and `mlr3forecasting`.
```